### PR TITLE
[fix-1]  fix  checkedItem methods scrollToItem isArray 

### DIFF
--- a/index.vue
+++ b/index.vue
@@ -545,7 +545,7 @@
         scrollToItem = this.$refs[ref + '_text_' + idx]
 
         if (scrollToItem) {
-          scrollToItem = scrollToItem instanceof Array
+          scrollToItem = Array.isArray(scrollToItem)
             ? scrollToItem.length > 0 ? scrollToItem[0] : null
             : scrollToItem;
           if (scrollToItem) {


### PR DESCRIPTION

fixed  https://github.com/muzin/weex-x-picker/issues/1 

fix checkedItem methods scrollToItem isArray

scrollToItem instanceof Array -> Array.isArray(scrollToItem)